### PR TITLE
[Bugfix] Change logo image format when exporting to PDF from .webp to .jpg

### DIFF
--- a/frontend/lib/export-utils.ts
+++ b/frontend/lib/export-utils.ts
@@ -19,7 +19,7 @@ export function exportToPDF(transactions: Transaction[], dateFilter: string): vo
   try {
     const logoWidth = 60 // Ancho del logo en mm
     const logoHeight = 20 // Altura aproximada manteniendo la proporción
-    doc.addImage("/farmacias-brasil-logo.webp", "WEBP", 15, 10, logoWidth, logoHeight)
+    doc.addImage("/farmacias-brasil-logo.jpg", "JPG", 15, 10, logoWidth, logoHeight)
   } catch (error) {
     console.error("Error al añadir el logo al PDF:", error)
   }


### PR DESCRIPTION
Cambios:
-Se ha cambiado el formato de la imagen del logo en la generación del reporte PDF para ventas. El cambio se debe a errores visuales de la imagen formato .WEBP al no tener fondo.